### PR TITLE
Parse espeak -X Flag for word to phoneme word mappings

### DIFF
--- a/phonemizer/backend/espeak.py
+++ b/phonemizer/backend/espeak.py
@@ -301,8 +301,9 @@ class EspeakBackend(BaseBackend):
                         # such as, "a while" ~> "ɐ wˈaɪl". This comes out in the following shape; a while~|||~a#||waIl~|~|~ɐ wˈaɪl
                         # without handling it, text and phonemes would be equal to the following:
                         # ["a while", "a#||waIl"]. THis should be fixed to be in the form of ["a while", "a# waIl"]
-
+                        
                         text_and_phoneme[1] = text_and_phoneme[1].replace("||", " ")
+
                         temp_text_word_to_phoneme_word_mapping.append(text_and_phoneme)
 
                 # Append the mappings to the array:

--- a/phonemizer/backend/espeak.py
+++ b/phonemizer/backend/espeak.py
@@ -37,7 +37,7 @@ _ESPEAK_FLAGS_RE = re.compile(r'\(.+?\)')
 # a global variable being used to overload the default espeak installed on the
 # system. The user can choose an alternative espeak with the method
 # EspeakBackend.set_espeak_path().
-_ESPEAK_DEFAULT_PATH = '/Users/tedi/resemble/espeak-ng/yolo/bin/espeak-ng'
+_ESPEAK_DEFAULT_PATH = None
 
 
 class EspeakBackend(BaseBackend):

--- a/phonemizer/backend/espeak.py
+++ b/phonemizer/backend/espeak.py
@@ -243,8 +243,6 @@ class EspeakBackend(BaseBackend):
                         self.espeak_path(), self.language, self.ipa,
                         data.name, self.sep)
 
-                    print("command: " + command)
-
                     if self.logger:
                         self.logger.debug('running %s', command)
 
@@ -301,8 +299,12 @@ class EspeakBackend(BaseBackend):
                         # such as, "a while" ~> "ɐ wˈaɪl". This comes out in the following shape; a while~|||~a#||waIl~|~|~ɐ wˈaɪl
                         # without handling it, text and phonemes would be equal to the following:
                         # ["a while", "a#||waIl"]. THis should be fixed to be in the form of ["a while", "a# waIl"]
-                        
                         text_and_phoneme[1] = text_and_phoneme[1].replace("||", " ")
+                        # Remove prepended and trailing spaces if they are there.
+                        if text_and_phoneme[0][0] == ' ':
+                            text_and_phoneme[0] = text_and_phoneme[0][1:]
+                        if text_and_phoneme[0][-1] == ' ':
+                            text_and_phoneme[0] = text_and_phoneme[0][0:-1]
 
                         temp_text_word_to_phoneme_word_mapping.append(text_and_phoneme)
 

--- a/phonemizer/backend/espeak.py
+++ b/phonemizer/backend/espeak.py
@@ -288,7 +288,22 @@ class EspeakBackend(BaseBackend):
                 # [['this', 'DIs'], [' is', 'Iz'], [' to be', 't@bi']]
                 temp_text_word_to_phoneme_word_mapping = []
                 if mappings is not None:
-                    temp_text_word_to_phoneme_word_mapping = [mapping.split('~|||~') for mapping in mappings]
+                    for mapping in mappings:
+                        text_and_phoneme = mapping.split('~|||~')
+
+                        # Sometimes text words map to multiple phoneme words. Like "lunchroom" ~> "l'VntS ru:m"
+                        # This comes out in the following shape; lunchroom~|||~lVntS||ru:m~|~|~l'VntS ru:m
+                        # Without handling it, text_and_phoneme would be equal to the following:
+                        # ["lunchroom", "lVntS||ru:m"]
+                        # This should be fixed to be in the form of [["lunchroom", "lVntS ru:m"]]
+                        #
+                        # There is also another case where multiple words will map to multiple phonemes
+                        # such as, "a while" ~> "ɐ wˈaɪl". This comes out in the following shape; a while~|||~a#||waIl~|~|~ɐ wˈaɪl
+                        # without handling it, text and phonemes would be equal to the following:
+                        # ["a while", "a#||waIl"]. THis should be fixed to be in the form of ["a while", "a# waIl"]
+
+                        text_and_phoneme[1] = text_and_phoneme[1].replace("||", " ")
+                        temp_text_word_to_phoneme_word_mapping.append(text_and_phoneme)
 
                 # Append the mappings to the array:
                 text_word_to_phoneme_word_mapping.append(temp_text_word_to_phoneme_word_mapping)

--- a/phonemizer/backend/festival.py
+++ b/phonemizer/backend/festival.py
@@ -102,7 +102,7 @@ class FestivalBackend(BaseBackend):
     def supported_languages():
         return {'en-us': 'english-us'}
 
-    def _phonemize_aux(self, text, separator, strip):
+    def _phonemize_aux(self, text, separator, strip, return_word_mappings):
         """Return a phonemized version of `text` with festival
 
         This function is a wrapper on festival, a text to speech
@@ -125,7 +125,11 @@ class FestivalBackend(BaseBackend):
         b = self._process(a)
         c = self._postprocess(b, separator, strip)
 
-        return [line for line in c if line.strip() != ''], []
+        if return_word_mappings:
+            return [line for line in c if line.strip() != ''], []
+
+        return [line for line in c if line.strip() != '']
+
 
     @staticmethod
     def _double_quoted(line):

--- a/phonemizer/backend/festival.py
+++ b/phonemizer/backend/festival.py
@@ -125,7 +125,7 @@ class FestivalBackend(BaseBackend):
         b = self._process(a)
         c = self._postprocess(b, separator, strip)
 
-        return [line for line in c if line.strip() != '']
+        return [line for line in c if line.strip() != ''], []
 
     @staticmethod
     def _double_quoted(line):

--- a/phonemizer/backend/segments.py
+++ b/phonemizer/backend/segments.py
@@ -132,4 +132,4 @@ class SegmentsBackend(BaseBackend):
         phonemized = (p.replace('#', separator.word) for p in phonemized)
 
         # return the result as a list of utterances
-        return list(phonemized)
+        return list(phonemized), []

--- a/phonemizer/backend/segments.py
+++ b/phonemizer/backend/segments.py
@@ -112,7 +112,7 @@ class SegmentsBackend(BaseBackend):
         return segments.Profile(
             *[{'Grapheme': k, 'mapping': v} for k, v in g2p.items()])
 
-    def _phonemize_aux(self, text, separator, strip):
+    def _phonemize_aux(self, text, separator, strip, return_word_mappings):
         # tokenize the input text per utterance
         phonemized = (
             self.tokenizer(line, column='mapping', errors='strict')
@@ -131,5 +131,8 @@ class SegmentsBackend(BaseBackend):
         phonemized = (p.replace(' ', separator.phone) for p in phonemized)
         phonemized = (p.replace('#', separator.word) for p in phonemized)
 
+        if return_word_mappings:
+            return list(phonemized), []
+
         # return the result as a list of utterances
-        return list(phonemized), []
+        return list(phonemized)

--- a/phonemizer/phonemize.py
+++ b/phonemizer/phonemize.py
@@ -41,7 +41,7 @@ def phonemize(
         use_sampa=False,
         language_switch='keep-flags',
         njobs=1,
-        logger=get_logger()):
+        logger=get_logger(), return_word_mappings=False):
     """Multilingual text to phonemes converter
 
     Return a phonemized version of an input `text`, given its
@@ -169,4 +169,4 @@ def phonemize(
 
     # phonemize the input text
     return phonemizer.phonemize(
-        text, separator=separator, strip=strip, njobs=njobs)
+        text, separator=separator, strip=strip, njobs=njobs, return_word_mappings=return_word_mappings)


### PR DESCRIPTION
**What does this PR do?**
This PR introduces the new return_word_mappings parameter to the phonemize function to enable text to phoneme mappings for espeak backend only. In-turn when setting this value to True, appends the -X flag to espeak which prints out the mappings. See espeak PR here (coming soon).

**What did you do?**
- Added parameter return_word_mappings
- If return_word_mappings is true, append -X flag to espeak 
- If return_word_mappings is true, parse -X flag output
- If return_word_mappings is true, return phonemized text and phoneme mappings, else just return phonemized text.

**How did you test?**
- Through the python console
- Modified resembletron's call to phonemize inside the synthesis.py#prepare_symbol_seqs_with_ssml function (added in Resembletrons [PR #245](https://github.com/resemble-ai/Resembletron/pull/245))

**What should the reviewer look out for?**
Nothing.