### PR TITLE
Removed the cpu_count heuristic

### DIFF
--- a/phonemizer/__init__.py
+++ b/phonemizer/__init__.py
@@ -14,7 +14,7 @@
 # along with phonologizer. If not, see <http://www.gnu.org/licenses/>.
 """Multilingual text to phones converter"""
 
-__version__ = '2.2.2-resemble'
+__version__ = '2.2.2a-resemble'
 
 
 try:  # pragma: nocover

--- a/phonemizer/backend/espeak.py
+++ b/phonemizer/backend/espeak.py
@@ -203,7 +203,7 @@ class EspeakBackend(BaseEspeakBackend):
         else:
             # divide the input text in chunks, each chunk being processed in a
             # separate job
-            cpu_count = min(len(text), os.cpu_count())
+            cpu_count = os.cpu_count() if njobs == -1 else njobs
             text_chunks = chunks(text, cpu_count)
 
             # If using parallel jobs, disable the log as stderr is not


### PR DESCRIPTION
As discussed in [this thread](https://resembleai.slack.com/archives/CLECZ3DTQ/p1627983387023700), the heuristic is problematic with joblib's process pool. I suggest instead to let the number of jobs be controllable by the user, which will then most likely remain constant throughout the program execution.

@ZohaibAhmed should we increase version numbers here to force everyone to upgrade?